### PR TITLE
ex-1 done

### DIFF
--- a/src/components/ToastPlayground/RadioInput.js
+++ b/src/components/ToastPlayground/RadioInput.js
@@ -1,0 +1,35 @@
+import React from "react";
+
+import styles from "./ToastPlayground.module.css";
+export default function RadioInput({ options, onSelect }) {
+  const [selectedVariant, setSelectedVariant] = React.useState("");
+
+  return (
+    <div className={styles.row}>
+      <div className={styles.label}>Variant</div>
+      {options.map((item) => {
+        return (
+          <div
+            className={`${styles.inputWrapper} ${styles.radioWrapper}`}
+            key={`variant-${item}`}
+          >
+            <label htmlFor={`variant-${item}`}>
+              <input
+                checked={selectedVariant === item}
+                id={`variant-${item}`}
+                type="radio"
+                name="variant"
+                value={item}
+                onChange={(event) => {
+                  setSelectedVariant(event.target.value);
+                  onSelect(event.target.value);
+                }}
+              />
+              {item}
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ToastPlayground/TextInput.js
+++ b/src/components/ToastPlayground/TextInput.js
@@ -1,0 +1,30 @@
+import React from "react";
+
+import styles from "./ToastPlayground.module.css";
+
+export default function TextInput({ onChangeHandler }) {
+  const [selectedVariant, setSelectedVariant] = React.useState("");
+
+  return (
+    <div className={styles.row}>
+      <label
+        htmlFor="message"
+        className={styles.label}
+        style={{ alignSelf: "baseline" }}
+      >
+        Message
+      </label>
+      <div className={styles.inputWrapper}>
+        <textarea
+          id="message"
+          className={styles.messageInput}
+          value={selectedVariant}
+          onChange={(event) => {
+            setSelectedVariant(event.target.value);
+            onChangeHandler(event.target.value);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ToastPlayground/ToastPlayground.js
+++ b/src/components/ToastPlayground/ToastPlayground.js
@@ -1,12 +1,26 @@
-import React from 'react';
+import React from "react";
 
-import Button from '../Button';
+import Button from "../Button";
+import RadioInput from "./RadioInput";
+import TextInput from "./TextInput";
+import styles from "./ToastPlayground.module.css";
 
-import styles from './ToastPlayground.module.css';
-
-const VARIANT_OPTIONS = ['notice', 'warning', 'success', 'error'];
+const VARIANT_OPTIONS = ["notice", "warning", "success", "error"];
 
 function ToastPlayground() {
+  const [selectedVariant, setSelectedVariant] = React.useState("");
+  const [message, setMessage] = React.useState("");
+
+  const handleVariantSelect = (variant) => {
+    console.log({ variant });
+    setSelectedVariant(variant);
+  };
+
+  const handleMessageChange = (message) => {
+    console.log({ message });
+    setMessage(message);
+  };
+
   return (
     <div className={styles.wrapper}>
       <header>
@@ -15,43 +29,11 @@ function ToastPlayground() {
       </header>
 
       <div className={styles.controlsWrapper}>
-        <div className={styles.row}>
-          <label
-            htmlFor="message"
-            className={styles.label}
-            style={{ alignSelf: 'baseline' }}
-          >
-            Message
-          </label>
-          <div className={styles.inputWrapper}>
-            <textarea id="message" className={styles.messageInput} />
-          </div>
-        </div>
-
-        <div className={styles.row}>
-          <div className={styles.label}>Variant</div>
-          <div
-            className={`${styles.inputWrapper} ${styles.radioWrapper}`}
-          >
-            <label htmlFor="variant-notice">
-              <input
-                id="variant-notice"
-                type="radio"
-                name="variant"
-                value="notice"
-              />
-              notice
-            </label>
-
-            {/* TODO Other Variant radio buttons here */}
-          </div>
-        </div>
-
+        <TextInput onChangeHandler={handleMessageChange} />
+        <RadioInput options={VARIANT_OPTIONS} onSelect={handleVariantSelect} />
         <div className={styles.row}>
           <div className={styles.label} />
-          <div
-            className={`${styles.inputWrapper} ${styles.radioWrapper}`}
-          >
+          <div className={`${styles.inputWrapper} ${styles.radioWrapper}`}>
             <Button>Pop Toast!</Button>
           </div>
         </div>


### PR DESCRIPTION
Exercise 1: Wiring up form controls
In order to test our Toast component, we'll start by building a little playground. This will allow us to test our component throughout development.

Image showing a textarea and set of radio buttons, along with a “Pop Toast!” radio button

In ToastPlayground.js, you'll find most of the markup you'll need, but there are two problems:

All of the inputs are uncontrolled, meaning we can't easily access their values in React. We should use React state to drive all form controls.
We're only given a single radio button. We need one for each valid variant.
Our Toast component should support 4 different variants:

notice
warning
success
error
This first exercise is meant to be a review of the concepts learned in Module 1 and Module 2. So, it might be worth brushing up on some of those earlier lessons. In particular, the [Input Cheatsheet bonus lesson](https://courses.joshwcomeau.com/joy-of-react/02-state/11-bonus-cheatsheet) has some handy info about binding different types of form inputs!

Acceptance Criteria:

The “Message” textarea should be driven by React state
Using the data in the VARIANT_OPTIONS array, render 4 radio buttons within the “Variant” row. They should all be part of the same group (so that only one can be selected at a time). They should also be driven by React state.
There should be no key warnings in the console.