### PR TITLE
exercise 4

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,14 +1,15 @@
-import React from 'react';
+import React from "react";
 
-import ToastPlayground from '../ToastPlayground';
-import Footer from '../Footer';
+import ToastPlayground from "../ToastPlayground";
+import Footer from "../Footer";
+import ToastProvider from "../ToastProvider/ToastProvider";
 
 function App() {
   return (
-    <>
+    <ToastProvider>
       <ToastPlayground />
       <Footer />
-    </>
+    </ToastProvider>
   );
 }
 

--- a/src/components/ToastPlayground/ToastPlayground.js
+++ b/src/components/ToastPlayground/ToastPlayground.js
@@ -5,27 +5,24 @@ import RadioInput from "./RadioInput";
 import TextInput from "./TextInput";
 import ToastShelf from "../ToastShelf";
 import styles from "./ToastPlayground.module.css";
-
-const VARIANT_OPTIONS = ["notice", "warning", "success", "error"];
-
-export const MessageListContext = React.createContext();
+import { ToastContext } from "../ToastProvider";
 
 function ToastPlayground() {
-  const [selectedVariant, setSelectedVariant] = React.useState(
-    VARIANT_OPTIONS[0]
-  );
-  const [message, setMessage] = React.useState("");
-  const [messageList, setMessageList] = React.useState([]);
+  const {
+    selectedVariant,
+    setSelectedVariant,
+    message,
+    setMessage,
+    setMessageList,
+    VARIANT_OPTIONS,
+  } = React.useContext(ToastContext);
+
   const handleVariantSelect = (variant) => {
     setSelectedVariant(variant);
   };
 
   const handleMessageChange = (message) => {
     setMessage(message);
-  };
-
-  const handleMessageListUpdate = (list) => {
-    setMessageList(list);
   };
 
   function handlePopToast(event) {
@@ -35,44 +32,41 @@ function ToastPlayground() {
       message,
       id: Math.random().toString(16).slice(2),
     };
-    setMessageList((prevMessageList) => [...prevMessageList, toast]);
+
+    setMessageList((messageList) => [...messageList, toast]);
     setMessage("");
     setSelectedVariant(VARIANT_OPTIONS[0]);
   }
-  //TODO: onSubmit radio input has strange default val, it should be set to notice
+
   return (
-    <MessageListContext.Provider value={messageList}>
-      <div className={styles.wrapper}>
-        <header>
-          <img alt="Cute toast mascot" src="/toast.png" />
-          <h1>Toast Playground</h1>
-        </header>
-        <ToastShelf
-          toastList={messageList}
-          onListChange={handleMessageListUpdate}
-        />
-        <div className={styles.controlsWrapper}>
-          <form
-            onSubmit={(e) => {
-              handlePopToast(e);
-            }}
-          >
-            <TextInput onChangeHandler={handleMessageChange} value={message} />
-            <RadioInput
-              options={VARIANT_OPTIONS}
-              onSelect={handleVariantSelect}
-              value={selectedVariant}
-            />
-            <div className={styles.row}>
-              <div className={styles.label} />
-              <div className={`${styles.inputWrapper} ${styles.radioWrapper}`}>
-                <Button type="submit">Pop Toast!</Button>
-              </div>
+    <div className={styles.wrapper}>
+      <header>
+        <img alt="Cute toast mascot" src="/toast.png" />
+        <h1>Toast Playground</h1>
+      </header>
+
+      <ToastShelf />
+      <div className={styles.controlsWrapper}>
+        <form
+          onSubmit={(e) => {
+            handlePopToast(e);
+          }}
+        >
+          <TextInput onChangeHandler={handleMessageChange} value={message} />
+          <RadioInput
+            options={VARIANT_OPTIONS}
+            onSelect={handleVariantSelect}
+            value={selectedVariant}
+          />
+          <div className={styles.row}>
+            <div className={styles.label} />
+            <div className={`${styles.inputWrapper} ${styles.radioWrapper}`}>
+              <Button type="submit">Pop Toast!</Button>
             </div>
-          </form>
-        </div>
+          </div>
+        </form>
       </div>
-    </MessageListContext.Provider>
+    </div>
   );
 }
 

--- a/src/components/ToastProvider/ToastProvider.js
+++ b/src/components/ToastProvider/ToastProvider.js
@@ -1,0 +1,30 @@
+import React from "react";
+
+export const ToastContext = React.createContext();
+const VARIANT_OPTIONS = ["notice", "warning", "success", "error"];
+
+function ToastProvider({ children }) {
+  const [selectedVariant, setSelectedVariant] = React.useState(
+    VARIANT_OPTIONS[0]
+  );
+  const [message, setMessage] = React.useState("");
+  const [messageList, setMessageList] = React.useState([]);
+
+  return (
+    <ToastContext.Provider
+      value={{
+        selectedVariant,
+        setSelectedVariant,
+        message,
+        setMessage,
+        messageList,
+        setMessageList,
+        VARIANT_OPTIONS,
+      }}
+    >
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export default ToastProvider;

--- a/src/components/ToastProvider/index.js
+++ b/src/components/ToastProvider/index.js
@@ -1,0 +1,2 @@
+export * from './ToastProvider';
+export { default } from './ToastProvider';

--- a/src/components/ToastShelf/ToastShelf.js
+++ b/src/components/ToastShelf/ToastShelf.js
@@ -2,20 +2,23 @@ import React from "react";
 
 import Toast from "../Toast";
 import styles from "./ToastShelf.module.css";
+import { ToastContext } from "../ToastProvider/ToastProvider";
 
-function ToastShelf({ toastList, onListChange }) {
-  const [toasts, setToasts] = React.useState([]);
+function ToastShelf() {
+  const { messageList, setMessageList } = React.useContext(ToastContext);
+
+  const [toasts, setToasts] = React.useState(messageList);
 
   React.useEffect(() => {
-    setToasts(toastList);
-  }, [toastList]);
+    setToasts(messageList);
+  }, [messageList]);
 
   function onDismissHandler(id) {
     const updMessageList = [...toasts].filter((item) => {
       return item.id !== id;
     });
     setToasts(updMessageList);
-    onListChange(updMessageList);
+    setMessageList(updMessageList);
   }
 
   return (


### PR DESCRIPTION
Exercise 4: Context
As it stands, all of our state has been managed by ToastPlayground. This works for our little demo app, but it wouldn't scale well in a real-world application!

In this exercise, we'll refactor our application to use the [“Provider component” pattern](https://courses.joshwcomeau.com/joy-of-react/04-component-design/08.04-provider-component). It will own all of the state related to the toasts state, and make it available to any child component who requires it.

Acceptance Criteria:

Create a new component, ToastProvider, that will serve as the “keeper” for all toast-related state.
To generate a new component, you can use the “new-component” script! Try tunning npm run new-component ToastProvider in the terminal.
Components that require the state should pull it from context with the useContext hook, rather than passing through props.
As we saw in the [“Provider Components” lesson](https://courses.joshwcomeau.com/joy-of-react/04-component-design/08.04-provider-component), we can also share functions that allow consumers to alter the state. Consider making functions available that will create a new toast, or dismiss a specific toast.
This is a “refactor” exercise. The user experience shouldn't change at all.